### PR TITLE
Fix tuple types

### DIFF
--- a/grammar/effect.js
+++ b/grammar/effect.js
@@ -31,8 +31,9 @@ module.exports = {
         $._type1
     ),
     parenthesized: $ => seq('(', $._value_type, ')'),
+    tuple_or_parenthesized_type: $ => seq('(', sep1(',', $._value_type), ')'),
     _value_type_leaf: $ => choice(
-        $.parenthesized,
+        $.tuple_or_parenthesized_type,
         $._type_atom,
         $.sequence_type,
     ),

--- a/test/corpus/large-tests.txt
+++ b/test/corpus/large-tests.txt
@@ -21,7 +21,7 @@ unique type heap.Heap a
         (kw_equals)
         (path) (wordy_id)
         (pipe)
-        (wordy_id) (wordy_id) (wordy_id) (parenthesized (path) (wordy_id) (wordy_id)) (parenthesized (path) (wordy_id) (wordy_id))
+        (wordy_id) (wordy_id) (wordy_id) (tuple_or_parenthesized_type (path) (wordy_id) (wordy_id)) (tuple_or_parenthesized_type  (path) (wordy_id) (wordy_id))
         ))
 ===
 [Large]  Heap.deleteMin
@@ -37,7 +37,7 @@ Heap.deleteMin cmp = cases
         (type_signature
             (path) (wordy_id) (type_signature_colon)
             (forall (kw_forall) (wordy_id) (wordy_id) (wordy_id))
-            (parenthesized (wordy_id) (arrow_symbol) 
+            (tuple_or_parenthesized_type  (wordy_id) (arrow_symbol) 
             (effect (wordy_id)) (wordy_id) (arrow_symbol) 
             (effect (wordy_id)) (wordy_id)) (arrow_symbol)
             (path) (wordy_id) (wordy_id) (arrow_symbol) 

--- a/test/corpus/term_declaration.txt
+++ b/test/corpus/term_declaration.txt
@@ -27,7 +27,7 @@ store.stopIfTrue = f a b c
 ---
 (unison
     (term_declaration
-        (type_signature (path) (wordy_id) (type_signature_colon) (parenthesized (wordy_id) (arrow_symbol) (wordy_id)) (arrow_symbol) (wordy_id) (arrow_symbol)
+        (type_signature (path) (wordy_id) (type_signature_colon) (tuple_or_parenthesized_type (wordy_id) (arrow_symbol) (wordy_id)) (arrow_symbol) (wordy_id) (arrow_symbol)
             (effect (wordy_id)) (effect (wordy_id) (wordy_id)) (wordy_id))
         (term_definition
             (path) (wordy_id)
@@ -39,3 +39,23 @@ store.stopIfTrue = f a b c
                     (function_application
                         (wordy_id)
                         (wordy_id)))))))
+===
+[Term] type signature with tuple
+===
+tup : (Nat, Nat)
+tup = (3, 3)
+---
+(unison
+  (term_declaration
+    (type_signature
+      (wordy_id)
+      (type_signature_colon)
+      (tuple_or_parenthesized_type
+        (wordy_id)
+        (wordy_id)))
+    (term_definition
+      (wordy_id)
+      (kw_equals)
+      (tuple_or_parenthesized
+        (nat)
+        (nat)))))


### PR DESCRIPTION
I just noticed that patterns like `(Nat, Nat)` produce an error.

I'm not 100% sure it's a good idea to combine `(Optional Nat)` and `(Nat, Nat)` as it feels lossy, but it repeats the pattern we have in terms.