### PR TITLE
Add term_type token

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -142,7 +142,7 @@ module.exports = grammar({
     type_signature: $ => seq(
       field('term_name', $._prefix_definition_name),
       $.type_signature_colon,
-      $.term_type,
+      alias($._value_type, $.term_type),
     ),
     
     type_variable: $ => regex.lowercase_varid,

--- a/grammar.js
+++ b/grammar.js
@@ -142,7 +142,7 @@ module.exports = grammar({
     type_signature: $ => seq(
       field('term_name', $._prefix_definition_name),
       $.type_signature_colon,
-      $._value_type,
+      $.term_type,
     ),
     
     type_variable: $ => regex.lowercase_varid,

--- a/grammar/effect.js
+++ b/grammar/effect.js
@@ -16,6 +16,7 @@ module.exports = {
         // optional(choice($.effect_inline, $._effect_block)),
         '}',
     ),
+    term_type: $ => $._value_type,
     
     /** 
      * Cannot have effects except as the RHS of an arrow

--- a/grammar/effect.js
+++ b/grammar/effect.js
@@ -16,7 +16,6 @@ module.exports = {
         // optional(choice($.effect_inline, $._effect_block)),
         '}',
     ),
-    term_type: $ => $._value_type,
     
     /** 
      * Cannot have effects except as the RHS of an arrow

--- a/test/corpus/blocks.txt
+++ b/test/corpus/blocks.txt
@@ -18,7 +18,7 @@
   (function_application (wordy_id) (operator) (nat))
   (kw_then)
   (term_declaration
-    (type_signature (wordy_id) (type_signature_colon) (wordy_id))
+    (type_signature (wordy_id) (type_signature_colon) (term_type (wordy_id)))
     (term_definition (wordy_id) (kw_equals) (parenthetical_exp (nat) (type_signature_colon) (wordy_id)) ))
   (function_application (wordy_id) (operator) (nat))
   (kw_else)

--- a/test/corpus/delayed-computations.txt
+++ b/test/corpus/delayed-computations.txt
@@ -13,12 +13,12 @@ program = do
         (type_signature
             (wordy_id)
             (type_signature_colon)
-            (delayed
+            (term_type (delayed
                 (effect
                     (wordy_id))
                 (effect
                     (wordy_id))
-                (unit)))
+                (unit))))
         (term_definition
             (wordy_id)
             (kw_equals)

--- a/test/corpus/large-tests.txt
+++ b/test/corpus/large-tests.txt
@@ -35,14 +35,14 @@ Heap.deleteMin cmp = cases
 (unison
     (term_declaration
         (type_signature
-            (path) (wordy_id) (type_signature_colon)
-            (forall (kw_forall) (wordy_id) (wordy_id) (wordy_id))
-            (parenthesized (wordy_id) (arrow_symbol) 
-            (effect (wordy_id)) (wordy_id) (arrow_symbol) 
-            (effect (wordy_id)) (wordy_id)) (arrow_symbol)
-            (path) (wordy_id) (wordy_id) (arrow_symbol) 
-            (effect (wordy_id)) (effect (wordy_id)) (path) (wordy_id) (wordy_id)
-        )
+            (path) (wordy_id) (type_signature_colon) (term_type
+                (forall (kw_forall) (wordy_id) (wordy_id) (wordy_id))
+                (parenthesized (wordy_id) (arrow_symbol) 
+                (effect (wordy_id)) (wordy_id) (arrow_symbol) 
+                (effect (wordy_id)) (wordy_id)) (arrow_symbol)
+                (path) (wordy_id) (wordy_id) (arrow_symbol) 
+                (effect (wordy_id)) (effect (wordy_id)) (path) (wordy_id) (wordy_id)
+            ))
         (term_definition
             (path) (wordy_id) (wordy_id) (kw_equals)
             (cases)

--- a/test/corpus/regression.txt
+++ b/test/corpus/regression.txt
@@ -62,5 +62,5 @@ x = 5
 (Numeric.>=) = todo "implement"
 ---
 (unison (term_declaration
-    (type_signature (path) (operator) (type_signature_colon) (wordy_id) (arrow_symbol) (wordy_id) (arrow_symbol) (wordy_id))
+    (type_signature (path) (operator) (type_signature_colon) (term_type (wordy_id) (arrow_symbol) (wordy_id) (arrow_symbol) (wordy_id)))
     (term_definition (path) (operator) (kw_equals) (function_application (wordy_id) (literal_text)))))

--- a/test/corpus/term_declaration.txt
+++ b/test/corpus/term_declaration.txt
@@ -17,7 +17,7 @@ sumUpTo x = x
 ---
 (unison
     (term_declaration
-        (type_signature (wordy_id) (type_signature_colon) (wordy_id) (arrow_symbol) (wordy_id))
+        (type_signature (wordy_id) (type_signature_colon) (term_type (wordy_id) (arrow_symbol) (wordy_id)))
         (term_definition (wordy_id) (wordy_id) (kw_equals) (wordy_id))))
 ===
 [Term] type signature with complex abilities clause
@@ -27,8 +27,12 @@ store.stopIfTrue = f a b c
 ---
 (unison
     (term_declaration
-        (type_signature (path) (wordy_id) (type_signature_colon) (parenthesized (wordy_id) (arrow_symbol) (wordy_id)) (arrow_symbol) (wordy_id) (arrow_symbol)
-            (effect (wordy_id)) (effect (wordy_id) (wordy_id)) (wordy_id))
+        (type_signature (path) (wordy_id) (type_signature_colon) (term_type 
+            (parenthesized (wordy_id) (arrow_symbol) (wordy_id))
+            (arrow_symbol) 
+            (wordy_id) 
+            (arrow_symbol)
+            (effect (wordy_id)) (effect (wordy_id) (wordy_id)) (wordy_id)))
         (term_definition
             (path) (wordy_id)
             (kw_equals)


### PR DESCRIPTION
Opening it just for discussion.


I was thinking how to highlight term names in my editor:

1. whole 1st-line term name + 1st-line term type as one group and 2nd-line term name and 2nd-line term definition (second line) as two other groups OR
2. term names as one group and then type / definition as other two

Then I decided that we should follow the highlighting rules from official UI. 

<img width="674" alt="Screenshot 2023-08-07 at 21 55 59" src="https://github.com/kylegoetz/tree-sitter-unison/assets/681171/7330dbb6-6237-4d7d-85f5-9cdd4da924b0">

Names here are highlighted the same way and then definition and type have their own highlighting.

This PR introduces a bit granularity to make the distinction possible.