### PR TITLE
Fix grammar to support bare type declarations

### DIFF
--- a/grammar/type.js
+++ b/grammar/type.js
@@ -58,7 +58,7 @@ module.exports = {
 
 
   _type_lhs: $ => seq(
-    choice($.structural, optional($.unique)),
+    optional(choice($.structural, $.unique)),
     $.type_kw,
     $.type_constructor
   ),

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -114,3 +114,17 @@ type UserId = Phone Nat | Email Text
         (pipe)
         (regular_identifier)
         (regular_identifier)))
+===
+[Types] bare record type declaration
+===
+type Task = { id : Nat }
+---
+(unison
+    (type_declaration
+        (type_kw)
+        (type_constructor (type_name (regular_identifier)))
+        (kw_equals)
+        (record
+            (record_field
+                (field_name)
+                (regular_identifier)))))


### PR DESCRIPTION
## Summary
- Make `structural` and `unique` keywords optional for type declarations
- Allows `type Task = { id : Nat }` to parse without requiring a prefix keyword

## Changes
- `grammar/type.js`: Changed `choice($.structural, optional($.unique))` to `optional(choice($.structural, $.unique))`
- Added test case for bare record type declarations

## Test plan
- All existing tests pass
- New test added for bare record type declaration

## Ref

https://www.unison-lang.org/docs/language-reference/user-defined-data-types/