### PR TITLE
Support bare type declarations

### DIFF
--- a/grammar/type.js
+++ b/grammar/type.js
@@ -58,7 +58,7 @@ module.exports = {
 
 
   _type_lhs: $ => seq(
-    choice($.structural, optional($.unique)),
+    optional(choice($.structural, $.unique)),
     $.type_kw,
     $.type_constructor
   ),

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -114,3 +114,17 @@ type UserId = Phone Nat | Email Text
         (pipe)
         (regular_identifier)
         (regular_identifier)))
+===
+[Types] bare record type declaration
+===
+type Task = { id : Nat }
+---
+(unison
+    (type_declaration
+        (type_kw)
+        (type_constructor (type_name (regular_identifier)))
+        (kw_equals)
+        (record
+            (record_field
+                (field_name)
+                (regular_identifier)))))


### PR DESCRIPTION
Makes `structural` and `unique` keywords optional in type declarations, allowing simpler syntax like `type Foo = Bar Nat`.

## Changes
- Modified `grammar/type.js` to make structural/unique optional
- Added test coverage in `test/corpus/types.txt`

## Example
```unison
type Foo = Bar Nat
```

Previously this required `structural type Foo = Bar Nat` or `unique type Foo = Bar Nat`.