### PR TITLE
Support character escape sequences with = prefix

### DIFF
--- a/grammar/literal.js
+++ b/grammar/literal.js
@@ -42,7 +42,11 @@ module.exports = {
 
   // Range: [-9223372036854775808, 9223372036854775807]
 
-  literal_char: ($) => choice(/\?./u, /\?\\[0abfnrtvs\'"]/),
+  literal_char: ($) => choice(
+    /\?\\[0abfnrtvs\'"\\]/,
+    /\?=./u,
+    /\?[^\\=]/u,
+  ),
   literal_boolean: ($) => choice("true", "false"),
   literal_byte: ($) => /0xs[0-9a-fA-F]+/,
   literal_hex: ($) => /0x[0-9a-fA-F]+/,

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -58,8 +58,10 @@ x = 1.6777216
 ===
 x = ?a
 x = ?\n
+x = ?=%
 ---
 (unison
+    (term_declaration (term_definition (regular_identifier) (kw_equals) (literal_char)))
     (term_declaration (term_definition (regular_identifier) (kw_equals) (literal_char)))
     (term_declaration (term_definition (regular_identifier) (kw_equals) (literal_char))))
 ===


### PR DESCRIPTION
Adds support for `?=` character literals (escape sequences with `=` prefix).

## Changes
- Modified `grammar/literal.js` to recognize `?=` syntax
- Added test coverage in `test/corpus/literals.txt`

## Example
```unison
?=a  -- Character with = prefix
```

This extends the character literal syntax to support escape sequences prefixed with `=`.