### PR TITLE
Add test for comment before type signature

### DIFF
--- a/test/corpus/comment.txt
+++ b/test/corpus/comment.txt
@@ -41,3 +41,22 @@ comment with -} nesting
             (kw_equals)
             (nat)
             (comment))))
+
+===
+[Comment] before type signature
+===
+-- Bytes literal
+someBytes : Bytes
+someBytes = 0xsdeadbeef
+---
+(unison
+    (comment)
+    (term_declaration
+        (type_signature
+            (regular_identifier)
+            (type_signature_colon)
+            (term_type (regular_identifier)))
+        (term_definition
+            (regular_identifier)
+            (kw_equals)
+            (literal_byte))))


### PR DESCRIPTION
Adds regression test verifying that comments immediately before type signatures parse correctly.

## Example verified
```unison
-- Bytes literal
someBytes : Bytes
someBytes = 0xsdeadbeef
```

## Changes
- Added test case in `test/corpus/comment.txt`

No grammar changes - the parser already handles this correctly. This test prevents future regressions.